### PR TITLE
fix: avoid catching Promise as a side effect

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -27,15 +27,15 @@ export default function memoize<A extends unknown[], R extends unknown, T extend
   return function (this: T, ...args: A) {
     const id = hash.apply(this, args)
     if (cache.has(id)) return cache.get(id)
-    let result = fn.apply(this, args)
+    const result = fn.apply(this, args)
+    cache.set(id, result)
     if (result instanceof Promise) {
       // eslint-disable-next-line github/no-then
-      result = result.catch(error => {
+      return result.catch(error => {
         cache.delete(id)
         throw error
-      }) as R
+      })
     }
-    cache.set(id, result)
     return result
   }
 }


### PR DESCRIPTION
I believe some engines treat the `result.catch()` call by creating a new Promise, resulting in us having two Promises in scope, meaning if one throws it gets caught by `unhandledRejection` and reported by our error reporting.

By re-assigning result to `result.catch()` we can ensure only one Promise "exists" in scope, thereby not triggering `unhandledRejection` warnings