### PR TITLE
Add cjs exports

### DIFF
--- a/decorator/package.json
+++ b/decorator/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@github/memoize/decorator",
+  "types": "../dist/esm/decorator.d.ts",
+  "main": "../dist/cjs/decorator.js",
+  "module": "../dist/esm/decorator.js",
+  "sideEffects": false
+}

--- a/package.json
+++ b/package.json
@@ -9,13 +9,23 @@
   "license": "MIT",
   "author": "GitHub Inc. (https://github.com)",
   "type": "module",
+  "main": "dist/cjs/index.js",
+  "module": "dist/esm/index.js",
   "exports": {
-    ".": "./dist/index.js",
-    "./decorator": "./dist/decorator.js"
+    ".": {
+      "module": "./dist/esm/index.js",
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js",
+      "types": "./dist/esm/index.d.ts"
+    },
+    "./decorator": {
+      "module": "./dist/esm/decorator.js",
+      "import": "./dist/esm/decorator.js",
+      "require": "./dist/cjs/decorator.js",
+      "types": "./dist/esm/decorator.d.ts"
+    }
   },
-  "main": "dist/index.js",
-  "module": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "./dist/esm/index.d.ts",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "types": "./dist/esm/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "decorator"
   ],
   "scripts": {
     "prebuild": "npm run clean && npm run lint && mkdir dist",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   ],
   "scripts": {
     "prebuild": "npm run clean && npm run lint && mkdir dist",
-    "build": "tsc",
+    "build": "npm run build:esm && npm run build:cjs",
+    "build:esm": "tsc",
+    "build:cjs": "tsc --module commonjs --outDir dist/cjs",
     "clean": "rm -rf dist",
     "lint": "eslint --report-unused-disable-directives . --color --ext .js,.ts,.tsx && tsc --noEmit",
     "prepublishOnly": "npm run build",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "node",
     "declaration": true,
     "declarationMap": true,
-    "outDir": "dist",
+    "outDir": "dist/esm",
     "experimentalDecorators": true
   },
   "exclude": ["test", "dist"]


### PR DESCRIPTION
`@github/memoize` currently only exports `esm`, which is great for modern projects.  However, there are a lot of build tools and test frameworks that still expect commonjs format, and will break if they receive esm.  With TypeScript, it's fairly easy to export _both_.  

There is also an existing issue with importing `@github/memoize/decorator`, which will fail if imported in typescript.  Adding the benign `decorator/package.json` here should fix that issue.

These strategies are all copied from https://github.com/primer/behaviors, where we have a very similar export strategy