### PR TITLE
Add `type: commonjs` package.json to cjs output

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "prebuild": "npm run clean && npm run lint && mkdir dist",
     "build": "npm run build:esm && npm run build:cjs",
     "build:esm": "tsc",
-    "build:cjs": "tsc --module commonjs --outDir dist/cjs",
+    "build:cjs": "tsc --module commonjs --outDir dist/cjs && echo '{\"type\": \"commonjs\"}' > dist/cjs/package.json",
     "clean": "rm -rf dist",
     "lint": "eslint --report-unused-disable-directives . --color --ext .js,.ts,.tsx && tsc --noEmit",
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
After #9, we have both commonJS and esm.  When imported from commonjs, it will resolve the cjs files, but it _iterprets_ them as esm because the nearest package.json is `type: module`

To fix this, we can add a new `package.json` in `dist/cjs` with `{ "type": "commonjs" }` to hint to node that the code is indeed cjs

Big thanks to @calebboyd for pointing this out!