### PR TITLE
Remove broken loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "lint": "eslint --report-unused-disable-directives . --color --ext .js,.ts,.tsx && tsc --noEmit",
     "prepublishOnly": "npm run build",
     "postpublish": "npm publish --ignore-scripts --@github:registry='https://npm.pkg.github.com'",
-    "test": "node --loader ts-node/esm.mjs node_modules/mocha/lib/cli/cli.js"
+    "test": "node node_modules/mocha/lib/cli/cli.js"
   },
   "prettier": "@github/prettier-config",
   "eslintConfig": {


### PR DESCRIPTION
CI Is failing with

```
> @github/memoize@1.1.1 test
> node --loader ts-node/esm.mjs node_modules/mocha/lib/cli/cli.js

(node:1724) ExperimentalWarning: Custom ESM Loaders is an experimental feature. This feature could change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Error [ERR_LOADER_CHAIN_INCOMPLETE]: "ts-node/esm.mjs 'resolve'" did not call the next hook in its chain and did not explicitly signal a short circuit. If this is intentional, include `shortCircuit: true` in the hook's return.
    at new NodeError (node:internal/errors:387:5)
    at ESMLoader.resolve (node:internal/modules/esm/loader:84[9](https://github.com/github/memoize/actions/runs/4809114771/jobs/8559931456#step:5:10):13)
    at async ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:7)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:530:24)
    at async loadESM (node:internal/process/esm_loader:91:5)
    at async handleMainPromise (node:internal/modules/run_main:65:[12](https://github.com/github/memoize/actions/runs/4809114771/jobs/8559931456#step:5:13)) {
  code: 'ERR_LOADER_CHAIN_INCOMPLETE'
}
Error: Process completed with exit code 1.
```