### PR TITLE
Build before publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm test
+      - run: npm build
       - run: |
           echo "Publishing $TAG_NAME"
           npm version ${TAG_NAME} --git-tag-version=false

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@github/memoize",
-  "version": "1.1.1",
+  "version": "0.0.0-dev",
   "description": "A simple Memoize helper, with TypeScript decorator support!",
   "repository": {
     "type": "git",
@@ -38,7 +38,6 @@
     "clean": "rm -rf dist",
     "lint": "eslint --report-unused-disable-directives . --color --ext .js,.ts,.tsx && tsc --noEmit",
     "prepublishOnly": "npm run build",
-    "postpublish": "npm publish --ignore-scripts --@github:registry='https://npm.pkg.github.com'",
     "test": "node --loader ts-node/esm.mjs node_modules/mocha/lib/cli/cli.js"
   },
   "prettier": "@github/prettier-config",


### PR DESCRIPTION
Release 1.1.3 did not include the `dist` directory because `build` was never run in the `publish` action. This is because the `publish` has `--ignore-scripts`. I added a new step which will run build before publishing.

I aslo removed the postpublish which used to push the package to GitHub Package Registry as we no longer target GHPR with any of these packages.