### PR TITLE
CI test with Node 20

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -6,10 +6,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 16.x
+    - name: Use Node.js 20.x
       uses: actions/setup-node@v2
       with:
-        node-version: 16.x
+        node-version: 20.x
     - name: npm install, build, and test
       run: |
         npm install
@@ -17,4 +17,3 @@ jobs:
         npm test
       env:
         CI: true
-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
           registry-url: https://registry.npmjs.org/
           cache: npm
       - run: npm ci


### PR DESCRIPTION
Node 20 is the LTS (also what's used in github/github)
It's soon [going into maintenance mode](https://nodejs.org/en/about/previous-releases) and we'll need to get ready for Node 22.